### PR TITLE
Field class: Error parsing "enum", "maximum" and "minimum" constraints

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -86,7 +86,7 @@ export class Field {
    * @returns {any}
    * @throws Error if value can't be cast
    */
-  castValue(value, constraints=true) {
+  castValue(value, constraints=false) {
 
     // Null value
     if (this._missingValues.includes(value)) {
@@ -161,7 +161,7 @@ export class Field {
 
   _getCheckFunctions() {
     const checks = {}
-    const cast = lodash.partial(this.castValue, lodash, false)
+    const cast = lodash.bind(this.castValue, this, lodash, false)
     for (const [name, constraint] of Object.entries(this.constraints)) {
       let castConstraint = constraint
       // Cast enum constraint
@@ -172,6 +172,7 @@ export class Field {
       if (['maximum', 'minimum'].includes(name)) {
         castConstraint = cast(constraint)
       }
+
       const func = constraints[`check${lodash.upperFirst(name)}`]
       const check = lodash.partial(func, castConstraint)
       checks[name] = check

--- a/src/field.js
+++ b/src/field.js
@@ -86,7 +86,7 @@ export class Field {
    * @returns {any}
    * @throws Error if value can't be cast
    */
-  castValue(value, constraints=false) {
+  castValue(value, constraints=true) {
 
     // Null value
     if (this._missingValues.includes(value)) {

--- a/test/field.js
+++ b/test/field.js
@@ -51,4 +51,45 @@ describe('Field', () => {
     })
   })
 
+
+  it('should parse descriptor with "enum" constraint', () => {
+    const field = new Field({
+      name: 'status',
+      type: 'string',
+      constraints: {
+        enum: ['active', 'inactive']
+      }
+    })
+
+    assert.equal(field.testValue('active'), true)
+    assert.equal(field.testValue('inactive'), true)
+  })
+
+  it('should parse descriptor with "minimum" constraint', () => {
+    const field = new Field({
+      name: 'length',
+      type: 'integer',
+      constraints: {
+        minimum: 100
+      }
+    })
+
+    assert.equal(field.testValue(200), true)
+    assert.equal(field.testValue(50), false)
+  })
+
+
+  it('should parse descriptor with "maximum" constraint', () => {
+    const field = new Field({
+      name: 'length',
+      type: 'integer',
+      constraints: {
+        maximum: 100
+      }
+    })
+
+    assert.equal(field.testValue(50), true)
+    assert.equal(field.testValue(200), false)
+  })
+
 })


### PR DESCRIPTION
The class failed to parse field definitions containing
constraints having attributes "**enum**", "**maximum**" and "**minimum**",
due to the `lodash.partial()` method usage.  In the implementation
of the `_getCheckFunctions()`, the casting function now gets invoked
using the `lodash.bind()` method that is the preferred way when
wanting to preserve the calling context.

See https://github.com/lodash/lodash/issues/748.