### PR TITLE
csv parser skips whitespace after delimiter - refs #80

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -157,7 +157,10 @@ module.exports = {
 // Internal
 
 async function createRowStream(source) {
-  const parser = csv.parse()
+  const parseOptions = {
+    ltrim: true
+  }
+  const parser = csv.parse(parseOptions)
   let stream
 
   // Stream factory


### PR DESCRIPTION
- fixes #80

---

Setting `ltrim=true` option for csv parser so it allows having whitespace after delimiter in csv data.