### PR TITLE
Support foreign key checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Factory method to instantiate `Table` class. This method is async and it should 
 - `headers (Integer/String[])` - data source headers (one of):
   - row number containing headers (`source` should contain headers rows)
   - array of headers (`source` should NOT contain headers rows)
-- `references (Array/Promise)` - array of foreign key references. Every array item should match correspondent `schema.foreignKeys` item. For example for a foreign key `field: [field1, field2], reference: ...` a references item should be `[[field1: value1, field2: value2]]`. This argument could be a promise.
+- `references (Array/Function)` - array of foreign key references. Every array item should match correspondent `schema.foreignKeys` item. For example for a foreign key `field: [field1, field2], reference: ...` a references item should be `[[field1: value1, field2: value2]]`. This argument could be a function returning an array promise.
 - `(errors.TableSchemaError)` - raises any error occured in table creation process
 - `(Table)` - returns data table class instance
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ stream.on('data', (row) => {
 
 It was onle basic introduction to the `Table` class. To learn more let's take a look on `Table` class API reference.
 
-#### `async Table.load(source, {schema, strict=false, headers=1, references=[]})`
+#### `async Table.load(source, {schema, strict=false, headers=1, references={}})`
 
 Factory method to instantiate `Table` class. This method is async and it should be used with await keyword or as a `Promise`. If `references` argument is provided foreign keys will be checked on any reading operation.
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ stream.on('data', (row) => {
 
 It was onle basic introduction to the `Table` class. To learn more let's take a look on `Table` class API reference.
 
-#### `async Table.load(source, {schema, strict=false, headers=1, references={}})`
+#### `async Table.load(source, {schema, strict=false, headers=1, references=[]})`
 
 Factory method to instantiate `Table` class. This method is async and it should be used with await keyword or as a `Promise`. If `references` argument is provided foreign keys will be checked on any reading operation.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Factory method to instantiate `Table` class. This method is async and it should 
 - `headers (Integer/String[])` - data source headers (one of):
   - row number containing headers (`source` should contain headers rows)
   - array of headers (`source` should NOT contain headers rows)
-- `references (Array/Function)` - array of foreign key references. Every array item should match correspondent `schema.foreignKeys` item. For example for a foreign key `field: [field1, field2], reference: ...` a references item should be `[[field1: value1, field2: value2]]`. This argument could be a function returning an array promise.
+- `references (Array/Function)` - array of foreign key references. Every array item should match correspondent `schema.foreignKeys` item. For example for a foreign key `field: [field1, field2], reference: ...` a references item should be `[[field1: value1, field2: value2], ...]`. This argument could be a function returning an array promise.
 - `(errors.TableSchemaError)` - raises any error occured in table creation process
 - `(Table)` - returns data table class instance
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ stream.on('data', (row) => {
 
 It was onle basic introduction to the `Table` class. To learn more let's take a look on `Table` class API reference.
 
-#### `async Table.load(source, {schema, strict=false, headers=1})`
+#### `async Table.load(source, {schema, strict=false, headers=1, references={}})`
 
 Factory method to instantiate `Table` class. This method is async and it should be used with await keyword or as a `Promise`.
 
@@ -181,10 +181,11 @@ Factory method to instantiate `Table` class. This method is async and it should 
   - array of arrays representing the rows
   - function returning readable stream with CSV file contents
 - `schema (Object)` - data schema in all forms supported by `Schema` class
+- `strict (Boolean)` - strictness option to pass to `Schema` constructor
 - `headers (Integer/String[])` - data source headers (one of):
   - row number containing headers (`source` should contain headers rows)
   - array of headers (`source` should NOT contain headers rows)
-- `strict (Boolean)` - strictness option to pass to `Schema` constructor
+- `references (Array/Promise)` - array of foreign key references. Every array item should match correspondent `schema.foreignKeys` item. For example for a foreign key `field: [field1, field2], reference: ...` a references item should be `[[field1: value1, field2: value2]]`. This argument could be a promise.
 - `(errors.TableSchemaError)` - raises any error occured in table creation process
 - `(Table)` - returns data table class instance
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Factory method to instantiate `Table` class. This method is async and it should 
 - `headers (Integer/String[])` - data source headers (one of):
   - row number containing headers (`source` should contain headers rows)
   - array of headers (`source` should NOT contain headers rows)
-- `references (Array/Function)` - array of foreign key references. Every array item should match correspondent `schema.foreignKeys` item. For example for a foreign key `field: [field1, field2], reference: ...` a references item should be `[[field1: value1, field2: value2], ...]`. This argument could be a function returning an array promise.
+- `references (Object/Function)` - object of foreign key references in a form of `{resource1: [{field1: value1, field2: value2}, ...], ...}`. This argument could be a function returning a promise.
 - `(errors.TableSchemaError)` - raises any error occured in table creation process
 - `(Table)` - returns data table class instance
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Iter through the table data and emits rows cast based on table schema (async for
 - `keyed (Boolean)` - iter keyed rows
 - `extended (Boolean)` - iter extended rows
 - `cast (Boolean)` - disable data casting if false
+- `check (Boolean)` - disable various checks if false
 - `stream (Boolean)` - return Node Readable Stream of table rows
 - `(errors.TableSchemaError)` - raises any error occured in this process
 - `(AsyncIterator/Stream)` - async iterator/stream of rows:
@@ -217,7 +218,8 @@ Read the whole table and returns as array of rows. Count of rows could be limite
 
 - `keyed (Boolean)` - flag to emit keyed rows
 - `extended (Boolean)` - flag to emit extended rows
-- `cast (Boolean)` - flag to disable data casting if false
+- `cast (Boolean)` - disable data casting if false
+- `check (Boolean)` - disable various checks if false
 - `limit (Number)` - integer limit of rows to return
 - `(errors.TableSchemaError)` - raises any error occured in this process
 - `(Array[])` - returns array of rows (see `table.iter`)

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ It was onle basic introduction to the `Table` class. To learn more let's take a 
 
 #### `async Table.load(source, {schema, strict=false, headers=1, references={}})`
 
-Factory method to instantiate `Table` class. This method is async and it should be used with await keyword or as a `Promise`.
+Factory method to instantiate `Table` class. This method is async and it should be used with await keyword or as a `Promise`. If `references` argument is provided foreign keys will be checked on any reading operation.
 
 - `source (String/Array[]/Function)` - data source (one of):
   - local CSV file (path)

--- a/src/errors.js
+++ b/src/errors.js
@@ -3,7 +3,7 @@ const ExtendableError = require('es6-error')
 
 // Module API
 
-class TableSchemaError extends ExtendableError {
+class DataPackageError extends ExtendableError {
 
   // Public
 
@@ -32,8 +32,12 @@ class TableSchemaError extends ExtendableError {
 }
 
 
+class TableSchemaError extends DataPackageError {}
+
+
 // System
 
 module.exports = {
+  DataPackageError,
   TableSchemaError,
 }

--- a/src/table.js
+++ b/src/table.js
@@ -82,7 +82,6 @@ class Table {
 
       // Form
       if (keyed) {
-        // TODO: schema.fieldNames to the mix!
         row = zipObject(this.headers, row)
       } else if (extended) {
         row = [rowNumber, this.headers, row]
@@ -99,16 +98,14 @@ class Table {
   async read({keyed, extended, cast=true, limit}={}) {
     const iterator = await this.iter({keyed, extended, cast})
     const rows = []
-    /* eslint-disable */
     let count = 0
     for (;;) {
       count += 1
       const iteration = await iterator.next()
       if (iteration.done) break
       rows.push(iteration.value)
-      if (limit && (count => limit)) break
+      if (limit && (count >= limit)) break
     }
-    /* eslint-enable */
     return rows
   }
 

--- a/src/table.js
+++ b/src/table.js
@@ -28,7 +28,7 @@ class Table {
   /**
    * https://github.com/frictionlessdata/tableschema-js#table
    */
-  static async load(source, {schema, strict=false, headers=1, references={}}={}) {
+  static async load(source, {schema, strict=false, headers=1, references=[]}={}) {
 
     // Load schema
     if (schema && !(schema instanceof Schema)) {

--- a/src/table.js
+++ b/src/table.js
@@ -27,7 +27,7 @@ class Table {
   /**
    * https://github.com/frictionlessdata/tableschema-js#table
    */
-  static async load(source, {schema, strict=false, headers=1, references=[]}={}) {
+  static async load(source, {schema, strict=false, headers=1, references={}}={}) {
 
     // Load schema
     if (schema && !(schema instanceof Schema)) {

--- a/src/table.js
+++ b/src/table.js
@@ -113,9 +113,10 @@ class Table {
         const keyedRow = zipObject(this.headers, row)
         for (const [fk, ref] of zip(this.schema.foreignKeys, this._references)) {
           if ([fk, ref].includes(undefined)) break
-          const fields = pick(keyedRow, fk.fields)
-          const found = find(ref, refFields => isMatch(refFields, fields))
-          if (!found) {
+          const values = pick(keyedRow, fk.fields)
+          const empty = Object.values(values).every(value => value === null)
+          const valid = find(ref, refValues => isMatch(refValues, values))
+          if (!empty && !valid) {
             const message = `Foreign key "${fk.fields}" violation in row "${rowNumber}"`
             throw new TableSchemaError(message)
           }

--- a/src/table.js
+++ b/src/table.js
@@ -116,7 +116,7 @@ class Table {
           const fields = pick(keyedRow, fk.fields)
           const found = find(ref, refFields => isMatch(refFields, fields))
           if (!found) {
-            const message = `Table violates foreign key in row "${rowNumber}"`
+            const message = `Foreign key "${fk.fields}" violation in row "${rowNumber}"`
             throw new TableSchemaError(message)
           }
         }

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,5 +1,4 @@
-const helpers = require('./helpers')
-const {Profile} = require('./profile')
+const {Schema} = require('./schema')
 
 
 // Module API
@@ -8,17 +7,8 @@ const {Profile} = require('./profile')
  * https://github.com/frictionlessdata/tableschema-js#validate
  */
 async function validate(descriptor) {
-
-  // Process descriptor
-  descriptor = await helpers.retrieveDescriptor(descriptor)
-  descriptor = helpers.expandSchemaDescriptor(descriptor)
-
-  // Get descriptor profile
-  const profile = await Profile.load('table-schema')
-
-  // Validate descriptor
-  return profile.validate(descriptor)
-
+  const {valid, errors} = await Schema.load(descriptor)
+  return {valid, errors}
 }
 
 

--- a/test/table.js
+++ b/test/table.js
@@ -124,6 +124,16 @@ describe('Table', () => {
       assert.deepEqual(table.schema.fields.length, 3)
     })
 
+    it('should throw on read for headers/fieldNames missmatch', async () => {
+      const source = [
+        ['id', 'bad', 'age', 'name', 'occupation'],
+        [1, '10.0', 1, 'string1', '2012-06-15 00:00:00'],
+      ]
+      const table = await Table.load(source, {schema: SCHEMA})
+      const error = await catchError(table.read.bind(table))
+      assert.include(error.message, 'match schema field names')
+    })
+
   })
 
   describe('#foreignKeys', () => {
@@ -162,8 +172,8 @@ describe('Table', () => {
 
     it('should read rows if multi field foreign keys is valid', async () => {
       const schema = cloneDeep(SCHEMA)
-      schema.foreignKeys[0].fields = ['name' ,'surname']
-      schema.foreignKeys[0].reference.fields = ['name' ,'surname']
+      schema.foreignKeys[0].fields = ['name', 'surname']
+      schema.foreignKeys[0].reference.fields = ['name', 'surname']
       const table = await Table.load(SOURCE, {schema})
       const rows = await table.read({references: REFERENCES})
       assert.deepEqual(rows.length, 3)
@@ -179,8 +189,8 @@ describe('Table', () => {
 
     it('should throw on read if multi field foreign keys is invalid', async () => {
       const schema = cloneDeep(SCHEMA)
-      schema.foreignKeys[0].fields = ['name' ,'surname']
-      schema.foreignKeys[0].reference.fields = ['name' ,'surname']
+      schema.foreignKeys[0].fields = ['name', 'surname']
+      schema.foreignKeys[0].reference.fields = ['name', 'surname']
       const references = cloneDeep(REFERENCES)
       delete references[0][2]
       const table = await Table.load(SOURCE, {schema})

--- a/test/table.js
+++ b/test/table.js
@@ -1,128 +1,193 @@
 const fs = require('fs')
 const {assert} = require('chai')
+const cloneDeep = require('lodash/cloneDeep')
 const {Table, Schema} = require('../src')
 const {catchError} = require('./helpers')
-
-
-// Fixtures
-
-const SOURCE = [
-  ['id', 'height', 'age', 'name', 'occupation'],
-  [1, '10.0', 1, 'string1', '2012-06-15 00:00:00'],
-  [2, '10.1', 2, 'string2', '2013-06-15 01:00:00'],
-  [3, '10.2', 3, 'string3', '2014-06-15 02:00:00'],
-  [4, '10.3', 4, 'string4', '2015-06-15 03:00:00'],
-  [5, '10.4', 5, 'string5', '2016-06-15 04:00:00']
-]
-const SCHEMA = {
-  fields: [
-    {name: 'id', type: 'integer', constraints: {required: true}},
-    {name: 'height', type: 'number'},
-    {name: 'age', type: 'integer'},
-    {name: 'name', type: 'string', constraints: {unique: true}},
-    {name: 'occupation', type: 'datetime', format: 'any'}
-  ],
-  primaryKey: 'id',
-}
 
 
 // Tests
 
 describe('Table', () => {
 
-  it('should not instantiate with bad schema path', async function() {
-    if (process.env.USER_ENV === 'browser') this.skip()
-    const error = await catchError(Table.load, SOURCE, {schema: 'bad schema path'})
-    assert.include(error.message, 'load descriptor')
-  })
-
-  it('should work with Schema instance', async () => {
-    const schema = await Schema.load(SCHEMA)
-    const table = await Table.load(SOURCE, {schema})
-    const rows = await table.read()
-    assert.equal(rows.length, 5)
-  })
-
-  it('should work with array source', async () => {
-    const table = await Table.load(SOURCE, {schema: SCHEMA})
-    const rows = await table.read()
-    assert.equal(rows.length, 5)
-  })
-
-  it('should work with readable stream factory', async function() {
-    if (process.env.USER_ENV === 'browser') this.skip()
-    const source = () => fs.createReadStream('data/data_big.csv')
-    const table = await Table.load(source)
-    const rows = await table.read()
-    assert.equal(rows.length, 100)
-  })
-
-  it('should work with local path', async function () {
-    if (process.env.USER_ENV === 'browser') this.skip()
-    const table = await Table.load('data/data_big.csv')
-    const rows = await table.read()
-    assert.equal(rows.length, 100)
-  })
-
-  it('should cast source data', async () => {
-    const table = await Table.load(SOURCE, {schema: SCHEMA})
-    const rows = await table.read()
-    assert.deepEqual(rows[0], [1, 10.0, 1, 'string1', new Date(2012, 6-1, 15)])
-  })
-
-  it('should not cast source data with cast false', async () => {
-    const table = await Table.load(SOURCE, {schema: SCHEMA})
-    const rows = await table.read({cast: false})
-    assert.deepEqual(rows[0], [1, '10.0', 1, 'string1', '2012-06-15 00:00:00'])
-  })
-
-  it('should throw on unique constraints violation', async () => {
-    const source = [
-      [1, '10.1', '1', 'string1', '2012-06-15'],
-      [2, '10.2', '2', 'string1', '2012-07-15'],
+  describe('#general', () => {
+    const SOURCE = [
+      ['id', 'height', 'age', 'name', 'occupation'],
+      [1, '10.0', 1, 'string1', '2012-06-15 00:00:00'],
+      [2, '10.1', 2, 'string2', '2013-06-15 01:00:00'],
+      [3, '10.2', 3, 'string3', '2014-06-15 02:00:00'],
+      [4, '10.3', 4, 'string4', '2015-06-15 03:00:00'],
+      [5, '10.4', 5, 'string5', '2016-06-15 04:00:00']
     ]
-    const table = await Table.load(source, {schema: SCHEMA, headers: false})
-    const error = await catchError(table.read.bind(table))
-    assert.include(error.message, 'duplicates')
+    const SCHEMA = {
+      fields: [
+        {name: 'id', type: 'integer', constraints: {required: true}},
+        {name: 'height', type: 'number'},
+        {name: 'age', type: 'integer'},
+        {name: 'name', type: 'string', constraints: {unique: true}},
+        {name: 'occupation', type: 'datetime', format: 'any'}
+      ],
+      primaryKey: 'id',
+    }
+
+    it('should not instantiate with bad schema path', async function() {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const error = await catchError(Table.load, SOURCE, {schema: 'bad schema path'})
+      assert.include(error.message, 'load descriptor')
+    })
+
+    it('should work with Schema instance', async () => {
+      const schema = await Schema.load(SCHEMA)
+      const table = await Table.load(SOURCE, {schema})
+      const rows = await table.read()
+      assert.equal(rows.length, 5)
+    })
+
+    it('should work with array source', async () => {
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const rows = await table.read()
+      assert.equal(rows.length, 5)
+    })
+
+    it('should work with readable stream factory', async function() {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const source = () => fs.createReadStream('data/data_big.csv')
+      const table = await Table.load(source)
+      const rows = await table.read()
+      assert.equal(rows.length, 100)
+    })
+
+    it('should work with local path', async function () {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const table = await Table.load('data/data_big.csv')
+      const rows = await table.read()
+      assert.equal(rows.length, 100)
+    })
+
+    it('should cast source data', async () => {
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const rows = await table.read()
+      assert.deepEqual(rows[0], [1, 10.0, 1, 'string1', new Date(2012, 6-1, 15)])
+    })
+
+    it('should not cast source data with cast false', async () => {
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const rows = await table.read({cast: false})
+      assert.deepEqual(rows[0], [1, '10.0', 1, 'string1', '2012-06-15 00:00:00'])
+    })
+
+    it('should throw on unique constraints violation', async () => {
+      const source = [
+        [1, '10.1', '1', 'string1', '2012-06-15'],
+        [2, '10.2', '2', 'string1', '2012-07-15'],
+      ]
+      const table = await Table.load(source, {schema: SCHEMA, headers: false})
+      const error = await catchError(table.read.bind(table))
+      assert.include(error.message, 'duplicates')
+    })
+
+    it('unique constraints violation for primary key', async () => {
+      const source = [
+        [1, '10.1', '1', 'string1', '2012-06-15'],
+        [1, '10.2', '2', 'string2', '2012-07-15'],
+      ]
+      const table = await Table.load(source, {schema: SCHEMA, headers: false})
+      const error = await catchError(table.read.bind(table))
+      assert.include(error.message, 'duplicates')
+    })
+
+    it('should read source data and limit rows', async () => {
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const rows = await table.read({limit: 1})
+      assert.deepEqual(rows.length, 1)
+    })
+
+    it('should read source data and return keyed rows', async () => {
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const rows = await table.read({keyed: true, limit: 1})
+      assert.deepEqual(rows[0],
+        {id: 1, height: 10.0, age: 1, name: 'string1', occupation: new Date(2012, 6-1, 15)})
+    })
+
+    it('should read source data and return extended rows', async () => {
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const rows = await table.read({extended: true, limit: 1})
+      assert.deepEqual(rows[0], [2,
+          ['id', 'height', 'age', 'name', 'occupation'],
+          [1, 10.0, 1, 'string1', new Date(2012, 6-1, 15)]])
+    })
+
+    it('should infer headers and schema', async function() {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const table = await Table.load('data/data_infer.csv')
+      await table.infer()
+      assert.deepEqual(table.headers, ['id', 'age', 'name'])
+      assert.deepEqual(table.schema.fields.length, 3)
+    })
+
   })
 
-  it('unique constraints violation for primary key', async () => {
-    const source = [
-      [1, '10.1', '1', 'string1', '2012-06-15'],
-      [1, '10.2', '2', 'string2', '2012-07-15'],
+  describe('#foreignKeys', () => {
+    const SOURCE = [
+      ['id', 'name', 'surname'],
+      ['1', 'Alex', 'Martin'],
+      ['2', 'John', 'Dockins'],
+      ['3', 'Walter', 'White'],
     ]
-    const table = await Table.load(source, {schema: SCHEMA, headers: false})
-    const error = await catchError(table.read.bind(table))
-    assert.include(error.message, 'duplicates')
-  })
+    const SCHEMA = {
+      fields: [
+        {name: 'id'},
+        {name: 'name'},
+        {name: 'surname'},
+      ],
+      foreignKeys: [
+        {
+          fields: 'name',
+          reference: {resource: 'people', fields: 'name'},
+        }
+      ]
+    }
+    const REFERENCES = [
+      [
+        {name: 'Alex', surname: 'Martin'},
+        {name: 'John', surname: 'Dockins'},
+        {name: 'Walter', surname: 'White'},
+      ]
+    ]
 
-  it('should read source data and limit rows', async () => {
-    const table = await Table.load(SOURCE, {schema: SCHEMA})
-    const rows = await table.read({limit: 1})
-    assert.deepEqual(rows.length, 1)
-  })
+    it('should read rows if single field foreign keys is valid', async () => {
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const rows = await table.read({references: REFERENCES})
+      assert.deepEqual(rows.length, 3)
+    })
 
-  it('should read source data and return keyed rows', async () => {
-    const table = await Table.load(SOURCE, {schema: SCHEMA})
-    const rows = await table.read({keyed: true, limit: 1})
-    assert.deepEqual(rows[0],
-      {id: 1, height: 10.0, age: 1, name: 'string1', occupation: new Date(2012, 6-1, 15)})
-  })
+    it('should read rows if multi field foreign keys is valid', async () => {
+      const schema = cloneDeep(SCHEMA)
+      schema.foreignKeys[0].fields = ['name' ,'surname']
+      schema.foreignKeys[0].reference.fields = ['name' ,'surname']
+      const table = await Table.load(SOURCE, {schema})
+      const rows = await table.read({references: REFERENCES})
+      assert.deepEqual(rows.length, 3)
+    })
 
-  it('should read source data and return extended rows', async () => {
-    const table = await Table.load(SOURCE, {schema: SCHEMA})
-    const rows = await table.read({extended: true, limit: 1})
-    assert.deepEqual(rows[0], [2,
-        ['id', 'height', 'age', 'name', 'occupation'],
-        [1, 10.0, 1, 'string1', new Date(2012, 6-1, 15)]])
-  })
+    it('should throw on read if single field foreign keys is invalid', async () => {
+      const references = cloneDeep(REFERENCES)
+      references[0][2].name = 'Max'
+      const table = await Table.load(SOURCE, {schema: SCHEMA})
+      const error = await catchError(table.read.bind(table), {references})
+      assert.include(error.message, 'violates foreign key')
+    })
 
-  it('should infer headers and schema', async function() {
-    if (process.env.USER_ENV === 'browser') this.skip()
-    const table = await Table.load('data/data_infer.csv')
-    await table.infer()
-    assert.deepEqual(table.headers, ['id', 'age', 'name'])
-    assert.deepEqual(table.schema.fields.length, 3)
+    it('should throw on read if multi field foreign keys is invalid', async () => {
+      const schema = cloneDeep(SCHEMA)
+      schema.foreignKeys[0].fields = ['name' ,'surname']
+      schema.foreignKeys[0].reference.fields = ['name' ,'surname']
+      const references = cloneDeep(REFERENCES)
+      delete references[0][2]
+      const table = await Table.load(SOURCE, {schema})
+      const error = await catchError(table.read.bind(table), {references})
+      assert.include(error.message, 'violates foreign key')
+    })
+
   })
 
 })

--- a/test/table.js
+++ b/test/table.js
@@ -153,7 +153,7 @@ describe('Table', () => {
         {
           fields: 'name',
           reference: {resource: 'people', fields: 'name'},
-        }
+        },
       ]
     }
     const REFERENCES = [
@@ -170,6 +170,14 @@ describe('Table', () => {
       assert.deepEqual(rows.length, 3)
     })
 
+    it('should throw on read if single field foreign keys is invalid', async () => {
+      const references = cloneDeep(REFERENCES)
+      references[0][2].name = 'Max'
+      const table = await Table.load(SOURCE, {schema: SCHEMA, references})
+      const error = await catchError(table.read.bind(table))
+      assert.include(error.message, 'violates foreign key')
+    })
+
     it('should read rows if multi field foreign keys is valid', async () => {
       const schema = cloneDeep(SCHEMA)
       schema.foreignKeys[0].fields = ['name', 'surname']
@@ -177,14 +185,6 @@ describe('Table', () => {
       const table = await Table.load(SOURCE, {schema, references: REFERENCES})
       const rows = await table.read()
       assert.deepEqual(rows.length, 3)
-    })
-
-    it('should throw on read if single field foreign keys is invalid', async () => {
-      const references = cloneDeep(REFERENCES)
-      references[0][2].name = 'Max'
-      const table = await Table.load(SOURCE, {schema: SCHEMA, references})
-      const error = await catchError(table.read.bind(table))
-      assert.include(error.message, 'violates foreign key')
     })
 
     it('should throw on read if multi field foreign keys is invalid', async () => {
@@ -198,8 +198,8 @@ describe('Table', () => {
       assert.include(error.message, 'violates foreign key')
     })
 
-    it('should support references as a promise', async () => {
-      const references = new Promise(resolve => resolve(REFERENCES))
+    it('should support references as a function', async () => {
+      const references = async () => REFERENCES
       const table = await Table.load(SOURCE, {schema: SCHEMA, references})
       const rows = await table.read()
       assert.deepEqual(rows.length, 3)

--- a/test/table.js
+++ b/test/table.js
@@ -152,17 +152,17 @@ describe('Table', () => {
       foreignKeys: [
         {
           fields: 'name',
-          reference: {resource: 'people', fields: 'name'},
+          reference: {resource: 'people', fields: 'firstname'},
         },
       ]
     }
-    const REFERENCES = [
-      [
-        {name: 'Alex', surname: 'Martin'},
-        {name: 'John', surname: 'Dockins'},
-        {name: 'Walter', surname: 'White'},
+    const REFERENCES = {
+      people: [
+        {firstname: 'Alex', surname: 'Martin'},
+        {firstname: 'John', surname: 'Dockins'},
+        {firstname: 'Walter', surname: 'White'},
       ]
-    ]
+    }
 
     it('should read rows if single field foreign keys is valid', async () => {
       const table = await Table.load(SOURCE, {schema: SCHEMA, references: REFERENCES})
@@ -172,7 +172,7 @@ describe('Table', () => {
 
     it('should throw on read if single field foreign keys is invalid', async () => {
       const references = cloneDeep(REFERENCES)
-      references[0][2].name = 'Max'
+      references.people[2].firstname = 'Max'
       const table = await Table.load(SOURCE, {schema: SCHEMA, references})
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'Foreign key')
@@ -181,7 +181,7 @@ describe('Table', () => {
     it('should read rows if multi field foreign keys is valid', async () => {
       const schema = cloneDeep(SCHEMA)
       schema.foreignKeys[0].fields = ['name', 'surname']
-      schema.foreignKeys[0].reference.fields = ['name', 'surname']
+      schema.foreignKeys[0].reference.fields = ['firstname', 'surname']
       const table = await Table.load(SOURCE, {schema, references: REFERENCES})
       const rows = await table.read()
       assert.deepEqual(rows.length, 3)
@@ -192,7 +192,7 @@ describe('Table', () => {
       schema.foreignKeys[0].fields = ['name', 'surname']
       schema.foreignKeys[0].reference.fields = ['name', 'surname']
       const references = cloneDeep(REFERENCES)
-      delete references[0][2]
+      delete references.people[2]
       const table = await Table.load(SOURCE, {schema, references})
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'Foreign key')

--- a/test/table.js
+++ b/test/table.js
@@ -175,7 +175,7 @@ describe('Table', () => {
       references[0][2].name = 'Max'
       const table = await Table.load(SOURCE, {schema: SCHEMA, references})
       const error = await catchError(table.read.bind(table))
-      assert.include(error.message, 'violates foreign key')
+      assert.include(error.message, 'Foreign key')
     })
 
     it('should read rows if multi field foreign keys is valid', async () => {
@@ -195,7 +195,7 @@ describe('Table', () => {
       delete references[0][2]
       const table = await Table.load(SOURCE, {schema, references})
       const error = await catchError(table.read.bind(table))
-      assert.include(error.message, 'violates foreign key')
+      assert.include(error.message, 'Foreign key')
     })
 
     it('should support references as a function', async () => {

--- a/test/table.js
+++ b/test/table.js
@@ -165,8 +165,8 @@ describe('Table', () => {
     ]
 
     it('should read rows if single field foreign keys is valid', async () => {
-      const table = await Table.load(SOURCE, {schema: SCHEMA})
-      const rows = await table.read({references: REFERENCES})
+      const table = await Table.load(SOURCE, {schema: SCHEMA, references: REFERENCES})
+      const rows = await table.read()
       assert.deepEqual(rows.length, 3)
     })
 
@@ -174,16 +174,16 @@ describe('Table', () => {
       const schema = cloneDeep(SCHEMA)
       schema.foreignKeys[0].fields = ['name', 'surname']
       schema.foreignKeys[0].reference.fields = ['name', 'surname']
-      const table = await Table.load(SOURCE, {schema})
-      const rows = await table.read({references: REFERENCES})
+      const table = await Table.load(SOURCE, {schema, references: REFERENCES})
+      const rows = await table.read()
       assert.deepEqual(rows.length, 3)
     })
 
     it('should throw on read if single field foreign keys is invalid', async () => {
       const references = cloneDeep(REFERENCES)
       references[0][2].name = 'Max'
-      const table = await Table.load(SOURCE, {schema: SCHEMA})
-      const error = await catchError(table.read.bind(table), {references})
+      const table = await Table.load(SOURCE, {schema: SCHEMA, references})
+      const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'violates foreign key')
     })
 
@@ -193,9 +193,16 @@ describe('Table', () => {
       schema.foreignKeys[0].reference.fields = ['name', 'surname']
       const references = cloneDeep(REFERENCES)
       delete references[0][2]
-      const table = await Table.load(SOURCE, {schema})
-      const error = await catchError(table.read.bind(table), {references})
+      const table = await Table.load(SOURCE, {schema, references})
+      const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'violates foreign key')
+    })
+
+    it('should support references as a promise', async () => {
+      const references = new Promise(resolve => resolve(REFERENCES))
+      const table = await Table.load(SOURCE, {schema: SCHEMA, references})
+      const rows = await table.read()
+      assert.deepEqual(rows.length, 3)
     })
 
   })


### PR DESCRIPTION
- improved `validate`
- connects https://github.com/frictionlessdata/datapackage-js/issues/82
- added additional describe level to `Table` tests (diff just because of indentations only FK tests are new)

---

On `tableschema` level we just accepts `references` argument for `Table` constructor. It's because `tableschema` layer is not responsible for integrity checks by itself but provides tools for it like `schema.foreignKeys` and table FK checks if `references` is passed. 

So on `datapackage` level those `references` should be composed. See this PR tests and readme diff for more `references` argument information. See `datapackage` implementation - https://github.com/frictionlessdata/datapackage-js/pull/89