### PR TITLE
[s]: accept stream as a source - refs #95

### DIFF
--- a/test/table.js
+++ b/test/table.js
@@ -48,6 +48,16 @@ describe('Table', () => {
       assert.equal(rows.length, 5)
     })
 
+    it('should work with stream as a source', async function() {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const stream = fs.createReadStream('data/data_big.csv')
+      const table = await Table.load(stream)
+      const rows = await table.read()
+      assert.equal(rows.length, 100)
+      const anotherRows = await table.read() // Reading second time
+      assert.equal(anotherRows.length, 100)
+    })
+
     it('should work with readable stream factory', async function() {
       if (process.env.USER_ENV === 'browser') this.skip()
       const source = () => fs.createReadStream('data/data_big.csv')


### PR DESCRIPTION
- fixes #95

---

* `/src/table.js:iter` - needed to duplicate a stream so it can be read multiple times
* `/src/table.js:createRowStream` - additional case when source is a stream
* `/test/tables.js` - test for reading table twice