### PR TITLE
Stick with moment@2.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "d3-time-format": "^0.3.2",
     "es6-error": "^4.0.2",
     "lodash": "^4.13.1",
-    "moment": "^2.13.0",
+    "moment": "~2.19.0",
     "regenerator-runtime": "^0.11.0",
     "stream-to-async-iterator": "^0.2.0",
     "tv4": "^1.2.7"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "d3-time-format": "^0.3.2",
     "es6-error": "^4.0.2",
     "lodash": "^4.13.1",
-    "moment": "~2.19.0",
+    "moment": "~2.18.0",
     "regenerator-runtime": "^0.11.0",
     "stream-to-async-iterator": "^0.2.0",
     "tv4": "^1.2.7"


### PR DESCRIPTION
`moment@2.19+` breaks our build https://travis-ci.org/frictionlessdata/tableschema-js/builds/286621255 (see `moment.locale` files removal in webpack)