### PR TITLE
Fixes #122.

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -141,7 +141,7 @@ class Schema {
   /**
    * https://github.com/frictionlessdata/tableschema-js#schema
    */
-  castRow(row, {failFast=false}={}) {
+  castRow(row, {failFast=false, forceCast=false}={}) {
     const result = []
     const errors = []
 
@@ -167,9 +167,12 @@ class Schema {
     // Raise errors
     if (errors.length) {
       const message = `There are ${errors.length} type and format mismatch errors (see 'error.errors')`
-      throw new TableSchemaError(message, errors)
+      if (!forceCast) {
+        throw new TableSchemaError(message, errors)
+      }
+      // may be less expensive to not throw, if we're collating errors
+      return new TableSchemaError(message, errors)
     }
-
     return result
   }
 

--- a/src/table.js
+++ b/src/table.js
@@ -59,7 +59,7 @@ class Table {
   /**
    * https://github.com/frictionlessdata/tableschema-js#table
    */
-  async iter({keyed, extended, cast=true, relations=false, stream=false}={}) {
+  async iter({keyed, extended, cast=true, relations=false, stream=false, forceCast=false}={}) {
     let source = this._source
 
     // Prepare unique checks
@@ -107,43 +107,46 @@ class Table {
       if (cast) {
         if (this.schema) {
           try {
-            row = this.schema.castRow(row)
+            row = this.schema.castRow(row, {failFast: false, forceCast})
           } catch (error) {
-            error.rowNumber = rowNumber
-            error.errors.forEach(error => {error.rowNumber = rowNumber})
+            handleRowError(error, rowNumber)
             throw error
           }
         }
       }
 
+      if (row instanceof Error) {
+        handleRowError(row, rowNumber)
+      } else {
       // Check unique
-      if (cast) {
-        for (const [indexes, cache] of Object.entries(uniqueFieldsCache)) {
-          const splitIndexes = indexes.split(',').map(index => parseInt(index, 10))
-          const values = row.filter((value, index) => splitIndexes.includes(index))
-          if (!values.every(value => value === null)) {
-            if (cache.data.has(values.toString())) {
-              const error = new TableSchemaError(
-                `Row ${rowNumber} has an unique constraint ` +
+        if (cast) {
+          for (const [indexes, cache] of Object.entries(uniqueFieldsCache)) {
+            const splitIndexes = indexes.split(',').map(index => parseInt(index, 10))
+            const values = row.filter((value, index) => splitIndexes.includes(index))
+            if (!values.every(value => value === null)) {
+              if (cache.data.has(values.toString())) {
+                const error = new TableSchemaError(
+                  `Row ${rowNumber} has an unique constraint ` +
                 `violation in column "${cache.name}"`)
-              error.rowNumber = rowNumber
-              throw error
+                error.rowNumber = rowNumber
+                throw error
+              }
+              cache.data.add(values.toString())
             }
-            cache.data.add(values.toString())
           }
         }
-      }
 
-      // Resolve relations
-      if (relations) {
-        if (this.schema) {
-          for (const foreignKey of this.schema.foreignKeys) {
-            row = resolveRelations(row, this.headers, relations, foreignKey)
-            if (row === null) {
-              const error = new TableSchemaError(
-                `Foreign key "${foreignKey.fields}" violation in row ${rowNumber}`)
-              error.rowNumber = rowNumber
-              throw error
+        // Resolve relations
+        if (relations) {
+          if (this.schema) {
+            for (const foreignKey of this.schema.foreignKeys) {
+              row = resolveRelations(row, this.headers, relations, foreignKey)
+              if (row === null) {
+                const error = new TableSchemaError(
+                  `Foreign key "${foreignKey.fields}" violation in row ${rowNumber}`)
+                error.rowNumber = rowNumber
+                throw error
+              }
             }
           }
         }
@@ -170,10 +173,10 @@ class Table {
   /**
    * https://github.com/frictionlessdata/tableschema-js#table
    */
-  async read({keyed, extended, cast=true, relations=false, limit}={}) {
+  async read({keyed, extended, cast=true, relations=false, limit, forceCast=false}={}) {
 
     // Get rows
-    const iterator = await this.iter({keyed, extended, cast, relations})
+    const iterator = await this.iter({keyed, extended, cast, relations, forceCast})
     const rows = []
     let count = 0
     for (;;) {
@@ -335,6 +338,10 @@ function createUniqueFieldsCache(schema) {
   return cache
 }
 
+function handleRowError(error, rowNumber) {
+  error.rowNumber = rowNumber
+  error.errors.forEach(error => {error.rowNumber = rowNumber})
+}
 
 function resolveRelations(row, headers, relations, foreignKey) {
 


### PR DESCRIPTION
Here's first attempt to add 'forceCast' flag. Used in both table.iter and schema.castRows (as per your advice @roll and as figured if collecting you don't want to keep throwing errors every time)
Left out field from forceCast as doesn't collect errors like rows.