### PR TITLE
Type URI now requires protocol scheme.

### DIFF
--- a/src/types/string.js
+++ b/src/types/string.js
@@ -13,7 +13,7 @@ function castString(format, value) {
     return ERROR
   }
   if (format === 'uri') {
-    if (!isURL(value)) {
+    if (!isURL(value, {require_protocol: true})) {
       return ERROR
     }
   } else if (format === 'email') {

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -11,6 +11,8 @@ const TESTS = [
   ['default', 0, ERROR],
   ['uri', 'http://google.com', 'http://google.com'],
   ['uri', 'ftp://example.org/resource.txt', 'ftp://example.org/resource.txt'],
+  ['uri', 'ftp://8.8.8.8', 'ftp://8.8.8.8'],
+  ['uri', '8.8.8.8', ERROR], // We require a protocol scheme (ftp:, http:, ...) in the URI
   ['uri', 'string', ERROR],
   ['uri', '', ERROR],
   ['uri', 0, ERROR],


### PR DESCRIPTION
This fix makes URI type consistent in `JS` & `PY` versions of `tableschema`.
Here https://github.com/frictionlessdata/tableschema-py/blob/7de2c803bbb0ee034c2f376be26466c8b956ae48/tableschema/types/string.py#L48 tableschema-py requires protocol to be presented in URI type, same will be required in JS version  from now.

`Infer()` method will treat value `8.8.8.8` as a **String with type Default**
Validator changed its behavior accordingly.

Fix issues:
frictionlessdata/tableschema-js#135
frictionlessdata/tableschema-py#204
datahq/pm#126
datahq/datahub-qa#121