### PR TITLE
Handle csv parse errors

### DIFF
--- a/data/defective_rows.csv
+++ b/data/defective_rows.csv
@@ -1,0 +1,3 @@
+id,name,age
+1101,John
+1102,Julie,26,Potatoes

--- a/src/profiles/table-schema.json
+++ b/src/profiles/table-schema.json
@@ -1540,7 +1540,6 @@
     },
     "missingValues": {
       "type": "array",
-      "minItems": 1,
       "items": {
         "type": "string"
       },
@@ -1550,7 +1549,8 @@
       "description": "Values that when encountered in the source, should be considered as `null`, 'not present', or 'blank' values.",
       "context": "Many datasets arrive with missing data values, either because a value was not collected or it never existed.\nMissing values may be indicated simply by the value being empty in other cases a special value may have been used e.g. `-`, `NaN`, `0`, `-9999` etc.\nThe `missingValues` property provides a way to indicate that these values should be interpreted as equivalent to null.\n\n`missingValues` are strings rather than being the data type of the particular field. This allows for comparison prior to casting and for fields to have missing value which are not of their type, for example a `number` field to have missing values indicated by `-`.\n\nThe default value of `missingValue` for a non-string type field is the empty string `''`. For string type fields there is no default for `missingValue` (for string fields the empty string `''` is a valid value and need not indicate null).",
       "examples": [
-        "{\n  \"missingValues\": [\n    \"-\",\n    \"NaN\",\n    \"\"\n  ]\n}\n"
+        "{\n  \"missingValues\": [\n    \"-\",\n    \"NaN\",\n    \"\"\n  ]\n}\n",
+        "{\n  \"missingValues\": []\n}\n"
       ]
     }
   },

--- a/src/table.js
+++ b/src/table.js
@@ -262,7 +262,7 @@ class Table {
 // Internal
 
 async function createRowStream(source, encoding, parserOptions) {
-  const parser = csv.parse({ltrim: true, ...parserOptions})
+  const parser = csv.parse({ltrim: true, relax_column_count: true, ...parserOptions})
   let stream
 
   // Stream factory

--- a/src/table.js
+++ b/src/table.js
@@ -332,10 +332,8 @@ function createCsvDelimiterDetector(csvParser) {
 
   detector.on('data', (chunk) => {
     if (!done) {
-      try {
-        const result = sniffer.sniff(chunk.toString())
-        csvParser.options.delimiter = result.delimiter
-      } catch (error) {}
+      const result = sniffer.sniff(chunk.toString())
+      csvParser.options.delimiter = result.delimiter
       done = true
     }
   })

--- a/src/table.js
+++ b/src/table.js
@@ -76,7 +76,7 @@ class Table {
 
     // Get table row stream
     let rowNumber = 0
-    let tableRowStream = rowStream.pipe(csv.transform(row => {
+    const tableRowStream = rowStream.pipe(csv.transform(row => {
       rowNumber += 1
 
       // Get headers
@@ -157,12 +157,20 @@ class Table {
       return row
     }))
 
-    // Form stream
-    if (!stream) {
-      tableRowStream = new S2A(tableRowStream)
+    // Handle csv errors
+    rowStream.on('error', () => {
+      const error = new TableSchemaError('Data source parsing error')
+      tableRowStream.emit('error', error)
+    })
+
+    // Return stream
+    if (stream) {
+      return tableRowStream
     }
 
-    return tableRowStream
+    // Return iterator
+    return new S2A(tableRowStream)
+
   }
 
   /**

--- a/src/table.js
+++ b/src/table.js
@@ -332,8 +332,10 @@ function createCsvDelimiterDetector(csvParser) {
 
   detector.on('data', (chunk) => {
     if (!done) {
-      const result = sniffer.sniff(chunk.toString())
-      csvParser.options.delimiter = result.delimiter
+      try {
+        const result = sniffer.sniff(chunk.toString())
+        csvParser.options.delimiter = result.delimiter
+      } catch (error) {}
       done = true
     }
   })

--- a/src/table.js
+++ b/src/table.js
@@ -307,11 +307,7 @@ async function createRowStream(source, encoding, parserOptions) {
   if (!isArray(source)) {
     if (parserOptions.delimiter === undefined) {
       const csvDelimiterDetector = createCsvDelimiterDetector(parser)
-      const snifferStream = stream.pipe(csvDelimiterDetector)
-      snifferStream.on('error', () => {
-        const error = new TableSchemaError('Data source dialect detection error')
-        stream.emit('error', error)
-      })
+      stream.pipe(csvDelimiterDetector)
     }
     stream = stream.pipe(parser)
   }

--- a/src/table.js
+++ b/src/table.js
@@ -307,7 +307,11 @@ async function createRowStream(source, encoding, parserOptions) {
   if (!isArray(source)) {
     if (parserOptions.delimiter === undefined) {
       const csvDelimiterDetector = createCsvDelimiterDetector(parser)
-      stream.pipe(csvDelimiterDetector)
+      const snifferStream = stream.pipe(csvDelimiterDetector)
+      snifferStream.on('error', () => {
+        const error = new TableSchemaError('Data source dialect detection error')
+        stream.emit('error', error)
+      })
     }
     stream = stream.pipe(parser)
   }

--- a/test/table.js
+++ b/test/table.js
@@ -192,7 +192,7 @@ Paris;48.85,2.30;2.244
 
     it('should be able to handle defective rows', async function() {
       if (process.env.USER_ENV === 'browser') this.skip()
-      const table = await Table.load('data/defective_rows.csv')
+      const table = await Table.load('data/defective_rows.csv', {delimiter: ''})
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'parsing error')
     })

--- a/test/table.js
+++ b/test/table.js
@@ -192,7 +192,7 @@ Paris;48.85,2.30;2.244
 
     it('should be able to handle defective rows', async function() {
       if (process.env.USER_ENV === 'browser') this.skip()
-      const table = await Table.load('data/defective_rows.csv', {delimiter: ''})
+      const table = await Table.load('data/defective_rows.csv')
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'parsing error')
     })

--- a/test/table.js
+++ b/test/table.js
@@ -194,9 +194,12 @@ Paris;48.85,2.30;2.244
       if (process.env.USER_ENV === 'browser') this.skip()
       // TODO: here we disable csvSniffer because of the following issue
       // (https://github.com/frictionlessdata/tableschema-js/issues/142)
-      const table = await Table.load('data/defective_rows.csv', {delimiter: ''})
-      const error = await catchError(table.read.bind(table))
-      assert.include(error.message, 'parsing error')
+      const table = await Table.load('data/defective_rows.csv', {delimiter: ','})
+      const rows = await table.read()
+      assert.deepEqual(rows, [
+        ['1101', 'John'],
+        ['1102', 'Julie', '26', 'Potatoes'],
+      ])
     })
 
     it('should be able to handle non-parsable csv files', async function() {

--- a/test/table.js
+++ b/test/table.js
@@ -192,7 +192,9 @@ Paris;48.85,2.30;2.244
 
     it('should be able to handle defective rows', async function() {
       if (process.env.USER_ENV === 'browser') this.skip()
-      const table = await Table.load('data/defective_rows.csv')
+      // TODO: here we disable csvSniffer because of the following issue
+      // (https://github.com/frictionlessdata/tableschema-js/issues/142)
+      const table = await Table.load('data/defective_rows.csv', {delimiter: ''})
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'parsing error')
     })

--- a/test/table.js
+++ b/test/table.js
@@ -189,6 +189,21 @@ Paris;48.85,2.30;2.244
       await table.read()
       assert.deepEqual(table.headers, ['city', 'location', 'population'])
     })
+
+    it('should be able to handle defective rows', async function() {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const table = await Table.load('data/defective_rows.csv')
+      const error = await catchError(table.read.bind(table))
+      assert.include(error.message, 'parsing error')
+    })
+
+    it('should be able to handle non-parsable csv files', async function() {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const table = await Table.load('data/schema.json')
+      const error = await catchError(table.read.bind(table))
+      assert.include(error.message, 'parsing error')
+    })
+
   })
 
   describe('#format', () => {


### PR DESCRIPTION
# Overview

- This PR solve the situation when unparsable CSV files hang the table on reading. As a solution, we re-emit the CSV parser stream (underlying) error to the transform stream (user-facing). Which seems working as we need.

- Also, we use `relax_column_count` option to allow parsing CSV files with irregular column number. For now, it works only with disabled `csvSniffer`. See - https://github.com/frictionlessdata/tableschema-js/issues/142