### PR TITLE
return semantic details in header error

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,6 +636,13 @@ try {
 
 - `(Number/undefined)` - column number of the error if available
 
+#### `errors.tableSchemaError.fieldNames`
+
+- `(Array/undefined)` - names of the fields in the tableschema
+
+#### `errors.tableSchemaError.headerNames`
+
+- `(Array/undefined)` - names of the headers in the table
 
 ## Contributing
 

--- a/src/table.js
+++ b/src/table.js
@@ -92,6 +92,8 @@ class Table {
             const error = new TableSchemaError(
               'The column header names do not match the field names in the schema')
             error.rowNumber = rowNumber
+            error.headerNames = this.headers
+            error.fieldNames = this.fieldNames
             if (forceCast) return error
             throw error
           }

--- a/test/table.js
+++ b/test/table.js
@@ -164,6 +164,8 @@ describe('Table', () => {
       const table = await Table.load(source, {schema: SCHEMA})
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'header names do not match the field names')
+      assert.deepEqual(error.headerNames, source[0])
+      assert.deepEqual(error.fieldNames, SCHEMA.headers)
     })
 
     it('should support user-defined constraints (issue #103)', async function() {


### PR DESCRIPTION
Add `headerNames` and `fieldNames` properties to the error object, when the headers do not match. This will allow downstream consumers to compare the two arrays and determine how to display the differences to the end user.