### PR TITLE
Support collecting all errors by type per row

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "dev": "webpack-dev-server --open --inline --hot",
     "lint": "eslint src test",
+    "prepare": "npm run build",
     "prepublish": "npm run build",
     "prepush": "npm run test",
     "posttest": "npm run lint",

--- a/src/table.js
+++ b/src/table.js
@@ -165,8 +165,8 @@ class Table {
         if (this.schema) {
           const errors = []
           for (const foreignKey of this.schema.foreignKeys) {
-            row = resolveRelations(row, this.headers, relations, foreignKey)
-            if (row === null) {
+            const newRow = resolveRelations(row, this.headers, relations, foreignKey)
+            if (newRow === null) {
               const error = new TableSchemaError(
                 `Foreign key "${foreignKey.fields}" violation in row ${rowNumber}`)
               error.rowNumber = rowNumber

--- a/test/table.js
+++ b/test/table.js
@@ -165,7 +165,7 @@ describe('Table', () => {
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'header names do not match the field names')
       assert.deepEqual(error.headerNames, source[0])
-      assert.deepEqual(error.fieldNames, SCHEMA.headers)
+      assert.deepEqual(error.fieldNames, ['id', 'height', 'age', 'name', 'occupation'])
     })
 
     it('should support user-defined constraints (issue #103)', async function() {
@@ -447,7 +447,7 @@ Paris;48.85,2.30;2.244
       const table = await Table.load(source, {schema})
       const rows = await table.read({forceCast: true})
       assert.deepEqual(rows[0], [1])
-      assert.include(rows[1].message, 'unique constraint violation')
+      assert.include(rows[1].errors[0].errors[0].message, 'unique constraint violation')
       assert.deepEqual(rows[2], [3])
     })
 


### PR DESCRIPTION
## Feature
Collect all errors per row when `table.iter/read({forceCast = true})`, and group them by type of check with `error.type`.