### PR TITLE
Resolves #114 dates are validated for short months and leap years

### DIFF
--- a/src/types/date.js
+++ b/src/types/date.js
@@ -14,7 +14,7 @@ function castDate(format, value) {
     }
     try {
       if (format === 'default') {
-        value = moment(timeParse(_DEFAULT_PATTERN)(value))
+        value = moment(value, _DEFAULT_PATTERN, true)
       } else if (format === 'any') {
         value = moment(value)
       } else {
@@ -45,4 +45,4 @@ module.exports = {
 
 // Internal
 
-const _DEFAULT_PATTERN = '%Y-%m-%d'
+const _DEFAULT_PATTERN = 'YYYY-MM-DD'

--- a/src/types/datetime.js
+++ b/src/types/datetime.js
@@ -14,7 +14,7 @@ function castDatetime(format, value) {
     }
     try {
       if (format === 'default') {
-        value = moment(timeParse(_DEFAULT_PATTERN)(value))
+        value = moment(value, _DEFAULT_PATTERN, true)
       } else if (format === 'any') {
         value = moment(value)
       } else {
@@ -45,4 +45,4 @@ module.exports = {
 
 // Internal
 
-const _DEFAULT_PATTERN = '%Y-%m-%dT%H:%M:%SZ'
+const _DEFAULT_PATTERN = 'YYYY-MM-DDTHH:mm:ss[Z]'

--- a/test/types/date.js
+++ b/test/types/date.js
@@ -32,6 +32,9 @@ const TESTS = [
   ['%d/%m/%y', true, ERROR],
   ['%d/%m/%y', '', ERROR],
   ['invalid', '21/11/06 16:30', ERROR],
+  ['default', '1999-11-31', ERROR],
+  ['default', '1999-02-29', ERROR],
+  ['default', '2000-02-29', date(2000, 2, 29)],
   // Deprecated
   ['fmt:%d/%m/%y', date(2019, 1, 1), date(2019, 1, 1)],
   ['fmt:%d/%m/%y', '21/11/06', date(2006, 11, 21)],


### PR DESCRIPTION
# Overview

What it says on the tin. Resolves #114. What was happening was that `moment.js` actually catches and throws errors on such things just fine, just that `d3-time-format` changes the supplied date to the next closest valid one, creating the error as described.

I changed it so that `default` uses a `moment.js` format string to parse the date, rather than using the `timeParse` of `d3-time-format`. `fmt` remains the same. I also chucked in a couple of tests for short months and leap dates.

---

Please preserve this line to notify @roll (lead of this repository)
