### PR TITLE
fix: fix base64 validation

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -327,7 +327,6 @@ const INSPECT_VALUE_GUESS_ORDER = [
   {type: 'number', format: 'default'},
   {type: 'boolean', format: 'default'},
   {type: 'string', format: 'uuid'},
-  {type: 'string', format: 'binary'},
   {type: 'string', format: 'email'},
   {type: 'string', format: 'uri'},
   {type: 'string', format: 'default'},

--- a/src/types/string.js
+++ b/src/types/string.js
@@ -25,7 +25,7 @@ function castString(format, value) {
       return ERROR
     }
   } else if (format === 'binary') {
-    if (!value.endsWith('==') || !isBase64(value)) {
+    if (!isBase64(value)) {
       return ERROR
     }
   }

--- a/test/infer.js
+++ b/test/infer.js
@@ -69,14 +69,6 @@ describe('infer', () => {
     ])
   })
 
-  it('could infer binary', async () => {
-    const data = [['dGVzdA==']]
-    const descriptor = await infer(data, {headers: ['name']})
-    assert.deepEqual(descriptor.fields, [
-      {name: 'name', type: 'string', format: 'binary'},
-    ])
-  })
-
   it('could infer geopoint', async () => {
     const data = [['90,45']]
     const descriptor = await infer(data, {headers: ['name']})

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -27,6 +27,8 @@ const TESTS = [
   ['uuid', 'string', ERROR],
   ['uuid', '', ERROR],
   ['uuid', 0, ERROR],
+  ['binary', 'YXN1cmUu', 'YXN1cmUu'],
+  ['binary', 'c3VyZS4=', 'c3VyZS4='],
   ['binary', 'dGVzdA==', 'dGVzdA=='],
   ['binary', 'string', ERROR],
   ['binary', '', ERROR],


### PR DESCRIPTION
Base64 strings end with 0, 1 or 2 '=' characters. It's incorrect to assume that they always end with "==".

I think we also have to remove inference for binary strings because:

- almost all "normal" strings which length is a multiple of 4 are also valid base64 strings
- we could detect if the strings end with a '=' character. But this would only occur with a probability of 2/3, whereas the threshold is set to 0.75 (`const INFER_CONFIDENCE = 0.75`)

See https://github.com/frictionlessdata/tableschema-js/issues/125#issuecomment-561679940.

---

Please preserve this line to notify @roll (lead of this repository)
