### PR TITLE
Include index.d.ts in the distribution package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "files": [
     "dist",
     "lib",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "npm run compile && npm run bundle",


### PR DESCRIPTION
# Overview

Typings were added in https://github.com/frictionlessdata/tableschema-js/pull/154, but are not part of the distributed package. After installing the package with `yarn add tableschema` this is what gets installed:

```
tree -L 1 node_modules/tableschema
node_modules/tableschema
├── LICENSE.md
├── README.md
├── dist
├── lib
├── node_modules
├── package.json
└── src
```

see https://docs.npmjs.com/files/package.json#files

---

Please preserve this line to notify @roll (lead of this repository)
