### PR TITLE
Surface the detected delimiter to the Table object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tableschema",
-  "version": "1.12.3",
+  "version": "1.12.4",
   "description": "A library for working with Table Schema in Javascript.",
   "license": "MIT",
   "main": "lib/index.js",

--- a/test/table.js
+++ b/test/table.js
@@ -171,6 +171,28 @@ describe('Table', () => {
       assert.deepEqual(table.schema.fields.length, 3)
     })
 
+    it('should contain stream options after infer', async function () {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const table = await Table.load('data/data_infer.csv')
+      await table.infer()
+      assert.deepEqual(table.headers, ['id', 'age', 'name'])
+      assert.deepEqual(table.schema.fields.length, 3)
+      assert.deepEqual(table.detectedParserOptions, {
+        delimiter: ',',
+      })
+    })
+
+    it('should contain stream options after infer for non comma delimiter', async function () {
+      if (process.env.USER_ENV === 'browser') this.skip()
+      const table = await Table.load('data/data_parse_options_delimiter.csv')
+      await table.infer()
+      assert.deepEqual(table.headers, ['id', 'age', 'name'])
+      assert.deepEqual(table.schema.fields.length, 3)
+      assert.deepEqual(table.detectedParserOptions, {
+        delimiter: ';',
+      })
+    })
+
     it('should throw on read for headers/fieldNames missmatch', async () => {
       const source = [
         ['id', 'bad', 'age', 'name', 'occupation'],


### PR DESCRIPTION
# Overview

It can be useful to expose the detected delimiter to the caller of infer() or read().  This PR will expose, for now, the delimiter detected when reading the CSV data.

---

Please preserve this line to notify @roll (lead of this repository)
