### PR TITLE
Add caseSensitive to Table constructor to schema field names validation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module "tableschema" {
     interface TSTableLoadOpts {
         schema?: SchemaDescriptor;
         strict?: boolean;
+        caseSensitive?: boolean;
         headers?: number | string[],
     }
 

--- a/test/table.js
+++ b/test/table.js
@@ -180,7 +180,7 @@ describe('Table', () => {
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'header names do not match the field names')
       assert.deepEqual(error.headerNames, source[0])
-      assert.deepEqual(error.fieldNames, SCHEMA.headers)
+      assert.deepEqual(error.fieldNames, table.schema.fieldNames)
     })
 
     it('should support user-defined constraints (issue #103)', async function () {


### PR DESCRIPTION
- fixes #185 

---

Base on the bug reported by @paulboony  at https://github.com/frictionlessdata/tableschema-js/issues/185 I implemented the option to load a table passing an argument caseSensitive, that will make the check between the table data header names and the field names on the schema case sensitive. For now I left the default as case sensitive, because this is the current tableschema-js behavior. 

You can now load a schema for a table not case sensitively as:

`const table = await Table.load('data.csv', { schema: 'schema.json', caseSensitive: false })`
