### PR TITLE
Update headers check to identify missing fields from the schema

### DIFF
--- a/test/table.js
+++ b/test/table.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const { Readable } = require('stream')
 const { assert } = require('chai')
 const cloneDeep = require('lodash/cloneDeep')
-const { Table, Schema } = require('../src')
+const { Schema, Table, TableSchemaError } = require('../src')
 const { catchError } = require('./helpers')
 const axios = require('axios').default
 
@@ -179,6 +179,11 @@ describe('Table', () => {
       const table = await Table.load(source, { schema: SCHEMA })
       const error = await catchError(table.read.bind(table))
       assert.include(error.message, 'header names do not match the field names')
+      assert.equal(error.errors.length, 1)
+      assert.deepEqual(
+        error._errors[0],
+        new TableSchemaError("The column header name 'height' is missing")
+      )
       assert.deepEqual(error.headerNames, source[0])
       assert.deepEqual(error.fieldNames, SCHEMA.headers)
     })


### PR DESCRIPTION
# Overview

When you get this error 'The column header names do not match the field names in the schema', it can be difficult to identify which columns are not matched with the schema, especially if you have a schema/csv with many columns.

Thus, I have updated the header validation to identify missing fields. The `TableSchemaError` errors are added as nested errors under existing 'The column header names do not match the field names in the schema' error, so existing behaviour is maintained, and you get additional information if needed.

---

Please preserve this line to notify @roll (lead of this repository)
